### PR TITLE
Allow kvdo to compile against 5.17 kernels

### DIFF
--- a/uds/uds-threads.c
+++ b/uds/uds-threads.c
@@ -172,7 +172,7 @@ void uds_thread_exit(void)
 	}
 	mutex_unlock(&kernel_thread_mutex);
 	uds_unregister_allocating_thread();
-	complete_and_exit(completion, 1);
+	kthread_complete_and_exit(completion, 1);
 }
 
 /**********************************************************************/


### PR DESCRIPTION
See: https://lore.kernel.org/lkml/20211208202532.16409-8-ebiederm@xmission.com/
complete_and_exit has been renamed to kthread_complete_and_exit