### PR TITLE
Allow compilation against 6.0.x kernels

### DIFF
--- a/vdo/dm-vdo-target.c
+++ b/vdo/dm-vdo-target.c
@@ -143,8 +143,8 @@ static void vdo_status(struct dm_target *ti,
 		vdo_fetch_statistics(vdo, &vdo->stats_buffer);
 		stats = &vdo->stats_buffer;
 
-		DMEMIT("/dev/%s %s %s %s %s %llu %llu",
-		       bdevname(vdo_get_backing_device(vdo), name_buffer),
+		DMEMIT("/dev/%d %s %s %s %s %llu %llu",
+		       snprintf(name_buffer, sizeof(name_buffer), "%pg", vdo_get_backing_device(vdo)),
 		       stats->mode,
 		       stats->in_recovery_mode ? "recovering" : "-",
 		       vdo_get_dedupe_index_state_name(vdo->dedupe_index),

--- a/vdo/io-factory.c
+++ b/vdo/io-factory.c
@@ -121,7 +121,7 @@ int make_uds_bufio(struct io_factory *factory,
 	}
 
 	client = dm_bufio_client_create(
-		factory->bdev, block_size, reserved_buffers, 0, NULL, NULL);
+		factory->bdev, block_size, reserved_buffers, 0, NULL, NULL, 0);
 	if (IS_ERR(client)) {
 		return -PTR_ERR(client);
 	}


### PR DESCRIPTION
bdevname - upstream removal, see:
https://github.com/torvalds/linux/commit/900d156bac2bc474cf7c7bee4efbc6c83ec5ae58

dm bufio: Add flags argument to dm_bufio_client_create, see: https://github.com/torvalds/linux/commit/0fcb100d50835d6823723ef0898cd565b3796e0a